### PR TITLE
feat: 유저 추가 정보(Additional Info) 관리 기능

### DIFF
--- a/apps/web/src/app/(dashboard)/profile/_Components/additionalInfo.tsx
+++ b/apps/web/src/app/(dashboard)/profile/_Components/additionalInfo.tsx
@@ -1,0 +1,37 @@
+import { CopyButton } from '@/components/copy-button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export type AdditionalInfoItem = {
+  id: string
+  name: string
+  data: string
+}
+
+export default function AdditionalInfo({
+  items
+}: {
+  items: AdditionalInfoItem[]
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Нэмэлт мэдээлэл</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4">
+          {items.map((item) => (
+            <div key={item.id} className="grid gap-1">
+              <h2 className="font-medium text-lg">{item.name}</h2>
+              <div className="flex items-center gap-2">
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {item.data}
+                </span>
+                <CopyButton textToCopy={item.data} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/app/(dashboard)/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/profile/page.tsx
@@ -1,3 +1,4 @@
+import prisma from '@gt/database'
 import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
@@ -5,6 +6,7 @@ import { redirect } from 'next/navigation'
 import { auth } from '@/utils/better-auth'
 import { getUser, getUserInfoById } from '@/utils/fetch'
 
+import AdditionalInfo from './_Components/additionalInfo'
 import AvatarDialog from './_Components/avatarDialog'
 import DangerZone from './_Components/dangerZone'
 import PersonalInfo, { type ExtendedUser } from './_Components/personalInfo'
@@ -39,6 +41,15 @@ export default async function Profile() {
     firstNameMgl: systemData?.FIRST_NAME_MGL,
     lastNameMgl: systemData?.LAST_NAME_MGL
   }
+
+  // 어드민이 수동 입력한 추가 정보 (읽기 전용 노출)
+  const additionalInfo = session?.user?.id
+    ? await prisma.userInfo.findMany({
+        where: { userId: session.user.id },
+        orderBy: { name: 'asc' }
+      })
+    : []
+
   return (
     <main>
       <div className="px-2">
@@ -54,6 +65,10 @@ export default async function Profile() {
           <PersonalInfo userData={userExtendedData} />
 
           {systemData && <SystemInfo systemData={systemData} />}
+
+          {additionalInfo.length > 0 && (
+            <AdditionalInfo items={additionalInfo} />
+          )}
         </div>
 
         <div className="mb-2">

--- a/apps/web/src/app/(sidebar)/_Components/Sidebar.tsx
+++ b/apps/web/src/app/(sidebar)/_Components/Sidebar.tsx
@@ -59,6 +59,10 @@ const data = {
         {
           title: 'User list',
           url: '/admin/users'
+        },
+        {
+          title: 'Additional info',
+          url: '/admin/users/info'
         }
       ]
     }

--- a/apps/web/src/app/(sidebar)/admin/users/_Components/UserInfoSheet.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/_Components/UserInfoSheet.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { ClipboardList } from 'lucide-react'
+import * as React from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+} from '@/components/ui/sheet'
+
+import { UserInfoEditor } from '../info/_Components/UserInfoEditor'
+
+interface UserInfoSheetProps {
+  userId: string
+  userName: string
+}
+
+export default function UserInfoSheet({
+  userId,
+  userName
+}: UserInfoSheetProps) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label={`${userName}-н нэмэлт мэдээлэл`}
+          title="Нэмэлт мэдээлэл"
+        >
+          <ClipboardList className="h-4 w-4" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-full overflow-y-auto sm:max-w-2xl"
+      >
+        <SheetHeader>
+          <SheetTitle>{userName} — Нэмэлт мэдээлэл</SheetTitle>
+          <SheetDescription>
+            Админ гараар оруулсан нэмэлт мэдээлэл
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* 시트가 열렸을 때만 마운트되어 그때 조회한다 */}
+        {open && (
+          <div className="px-4 pb-4">
+            <UserInfoEditor userId={userId} />
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/_Components/UserTable.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/_Components/UserTable.tsx
@@ -43,6 +43,7 @@ import { SessionsDialog } from './SessionsDialog'
 import { SetPasswordDialog } from './SetPasswordDialog'
 import { UserDetailDialog } from './UserDetailDialog'
 import UserGradesSheet from './UserGradesSheet'
+import UserInfoSheet from './UserInfoSheet'
 
 export interface UserData {
   id: string
@@ -146,6 +147,7 @@ export function UserTable() {
                 userName={user.name}
               />
             )}
+            <UserInfoSheet userId={user.id} userName={user.name} />
           </div>
         )
       }

--- a/apps/web/src/app/(sidebar)/admin/users/info/_Components/AllInfoList.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/_Components/AllInfoList.tsx
@@ -1,0 +1,397 @@
+'use client'
+
+import {
+  type ColumnDef,
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable
+} from '@tanstack/react-table'
+import { ArrowUpDown, Download, Loader2, Search, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { givenNameSort } from '@/utils/name'
+
+import { ConfirmActionDialog } from '../../../grade/edit/_Components/ConfirmActionDialog'
+import { deleteUserInfoBulk, listFieldNames, loadAllUserInfo } from '../actions'
+import type { UserInfoListRow } from '../types'
+
+const GENERIC_ERROR = 'Алдаа гарлаа. Дахин оролдоно уу.'
+const ALL_FIELDS = '__all__'
+const PAGE_SIZE = 50
+
+// CSV 셀 이스케이프 (쉼표/따옴표/줄바꿈 포함 시 따옴표로 감싸기)
+function escapeCsv(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+function downloadCsv(rows: UserInfoListRow[]): void {
+  const header = ['Сурагч', 'Регистр', 'Нэр', 'Утга']
+  const lines = [
+    header.join(','),
+    ...rows.map((r) =>
+      [r.studentName, r.registerNumber, r.name, r.data]
+        .map((cell) => escapeCsv(cell))
+        .join(',')
+    )
+  ]
+  // Excel에서 UTF-8(키릴/한글) 인식을 위해 BOM 추가
+  const blob = new Blob([`﻿${lines.join('\r\n')}`], {
+    type: 'text/csv;charset=utf-8'
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'user-info.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+const columns: ColumnDef<UserInfoListRow>[] = [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && 'indeterminate')
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Бүгдийг сонгох"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Мөр сонгох"
+      />
+    ),
+    enableSorting: false
+  },
+  {
+    accessorKey: 'studentName',
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      >
+        Сурагч <ArrowUpDown className="ml-1 size-4" />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <span className="font-medium">{row.getValue('studentName')}</span>
+    ),
+    sortingFn: givenNameSort,
+    filterFn: (row, columnId, value: string) =>
+      String(row.getValue(columnId)).toLowerCase().includes(value.toLowerCase())
+  },
+  {
+    accessorKey: 'registerNumber',
+    header: 'Регистр',
+    cell: ({ row }) => <div>{row.getValue('registerNumber')}</div>
+  },
+  {
+    accessorKey: 'name',
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      >
+        Нэр <ArrowUpDown className="ml-1 size-4" />
+      </Button>
+    ),
+    cell: ({ row }) => <div>{row.getValue('name')}</div>
+  },
+  {
+    accessorKey: 'data',
+    header: 'Утга',
+    cell: ({ row }) => <div>{row.getValue('data')}</div>
+  }
+]
+
+export function AllInfoList() {
+  const [fieldNames, setFieldNames] = useState<string[]>([])
+  const [field, setField] = useState<string>(ALL_FIELDS)
+
+  const [data, setData] = useState<UserInfoListRow[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [rowSelection, setRowSelection] = useState({})
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  useEffect(() => {
+    listFieldNames().then((result) => {
+      if (result.success) setFieldNames(result.data)
+    })
+  }, [])
+
+  const load = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = await loadAllUserInfo(
+        field === ALL_FIELDS ? undefined : field
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setData(result.data)
+      setRowSelection({})
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [field])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const table = useReactTable({
+    data,
+    columns,
+    getRowId: (row) => row.id,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: PAGE_SIZE } },
+    state: { sorting, columnFilters, rowSelection }
+  })
+
+  const filteredRows = table.getFilteredRowModel().rows
+  const selectedIds = table
+    .getFilteredSelectedRowModel()
+    .rows.map((row) => row.original.id)
+  const showSelectAllFiltered =
+    selectedIds.length > 0 && selectedIds.length < filteredRows.length
+
+  const selectAllFiltered = () => {
+    const next: Record<string, boolean> = {}
+    for (const row of filteredRows) next[row.id] = true
+    table.setRowSelection(next)
+  }
+
+  const nameFilter =
+    (table.getColumn('studentName')?.getFilterValue() as string) ?? ''
+
+  const handleExport = () => {
+    const rows = filteredRows.map((row) => row.original)
+    if (rows.length === 0) {
+      toast.error('Экспортлох мэдээлэл алга байна')
+      return
+    }
+    downloadCsv(rows)
+  }
+
+  const runDelete = async () => {
+    if (selectedIds.length === 0) return
+    setIsDeleting(true)
+    try {
+      const result = await deleteUserInfoBulk({ ids: selectedIds })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(`${result.count} мөр устгагдлаа`)
+      setDeleteOpen(false)
+      await load()
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={field} onValueChange={(value) => setField(value)}>
+          <SelectTrigger className="w-56">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_FIELDS}>Бүх талбар</SelectItem>
+            {fieldNames.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="relative w-56">
+          <Search className="-translate-y-1/2 absolute top-1/2 left-2 size-4 text-muted-foreground" />
+          <Input
+            className="pl-8"
+            placeholder="Сурагчийн нэрээр шүүх"
+            value={nameFilter}
+            onChange={(e) =>
+              table.getColumn('studentName')?.setFilterValue(e.target.value)
+            }
+          />
+        </div>
+
+        <Button
+          className="ml-auto"
+          variant="outline"
+          onClick={handleExport}
+          disabled={isLoading || filteredRows.length === 0}
+        >
+          <Download className="size-4" /> CSV
+        </Button>
+      </div>
+
+      {selectedIds.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+          <span className="font-medium text-sm">
+            {selectedIds.length} мөр сонгосон
+          </span>
+          {showSelectAllFiltered && (
+            <Button
+              variant="link"
+              className="h-auto p-0"
+              onClick={selectAllFiltered}
+            >
+              Шүүлтэд тохирох бүх {filteredRows.length} мөрийг сонгох
+            </Button>
+          )}
+          <Button
+            variant="destructive"
+            className="ml-auto"
+            disabled={isDeleting}
+            onClick={() => setDeleteOpen(true)}
+          >
+            <Trash2 className="mr-1 size-4" /> Устгах
+          </Button>
+        </div>
+      )}
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  <Loader2 className="mx-auto size-6 animate-spin text-muted-foreground" />
+                </TableCell>
+              </TableRow>
+            ) : table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && 'selected'}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-muted-foreground"
+                >
+                  Мэдээлэл алга байна
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <div className="flex-1 text-muted-foreground text-sm">
+          {selectedIds.length} / {filteredRows.length} мөр сонгосон
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Өмнөх
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Дараах
+        </Button>
+      </div>
+
+      <ConfirmActionDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title="Нэмэлт мэдээлэл устгах"
+        description={`${selectedIds.length} мөрийг устгах уу? Энэ үйлдлийг буцаах боломжгүй.`}
+        confirmLabel="Устгах"
+        destructive
+        isLoading={isDeleting}
+        onConfirm={runDelete}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/_Components/BulkInfoEditor.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/_Components/BulkInfoEditor.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { Textarea } from '@/components/ui/textarea'
+
+import { commitBulkUserInfo, previewBulkUserInfo } from '../actions'
+import type { PreviewRow, PreviewStatus } from '../types'
+
+const GENERIC_ERROR = 'Алдаа гарлаа. Дахин оролдоно уу.'
+
+const STATUS_BADGE: Record<
+  PreviewStatus,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  matched: { label: 'Олдсон', variant: 'default' },
+  ambiguous: { label: 'Сонгох', variant: 'secondary' },
+  not_found: { label: 'Олдсонгүй', variant: 'destructive' }
+}
+
+export function BulkInfoEditor() {
+  const [fieldName, setFieldName] = useState('')
+  const [raw, setRaw] = useState('')
+  const [rows, setRows] = useState<PreviewRow[] | null>(null)
+  // ambiguous 행에서 선택한 userId (index 기준)
+  const [selections, setSelections] = useState<Record<number, string>>({})
+  const [isPreviewing, setIsPreviewing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handlePreview = async () => {
+    if (!fieldName.trim() || !raw.trim()) {
+      toast.error('Талбарын нэр болон өгөгдлийг оруулна уу')
+      return
+    }
+    setIsPreviewing(true)
+    try {
+      const result = await previewBulkUserInfo({ raw })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setRows(result.data)
+      setSelections({})
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsPreviewing(false)
+    }
+  }
+
+  // 저장 가능한 항목: matched(userId) 또는 사용자가 선택한 ambiguous 행
+  const resolvedEntries = useMemo(
+    () =>
+      (rows ?? []).flatMap((row) => {
+        const userId =
+          row.status === 'matched' ? row.userId : selections[row.index]
+        if (!userId) return []
+        return [{ userId, data: row.data }]
+      }),
+    [rows, selections]
+  )
+
+  const handleSave = async () => {
+    if (resolvedEntries.length === 0) {
+      toast.error('Хадгалах боломжтой мөр алга байна')
+      return
+    }
+    setIsSaving(true)
+    try {
+      const result = await commitBulkUserInfo({
+        name: fieldName,
+        entries: resolvedEntries
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(`${result.count} мөр хадгалагдлаа`)
+      setRows(null)
+      setRaw('')
+      setSelections({})
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-2">
+        <Label htmlFor="field-name">Талбарын нэр</Label>
+        <Input
+          id="field-name"
+          placeholder="ж: Элсэлтийн ерөнхий шалгалтын дугаар"
+          value={fieldName}
+          onChange={(e) => setFieldName(e.target.value)}
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="bulk-data">Өгөгдөл (Excel-ээс хуулж тавина уу)</Label>
+        <Textarea
+          id="bulk-data"
+          className="min-h-40 font-mono text-sm"
+          placeholder={'Овог нэр\tутга\nОвог нэр\tутга'}
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          Мөр бүрт: нэр, таб (эсвэл таслал), утга. Excel-ийн нүднүүдийг шууд
+          хуулж болно.
+        </p>
+      </div>
+
+      <Button onClick={handlePreview} disabled={isPreviewing}>
+        {isPreviewing ? (
+          <Loader2 className="animate-spin" />
+        ) : (
+          'Урьдчилан харах'
+        )}
+      </Button>
+
+      {rows && (
+        <div className="space-y-4">
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-10">#</TableHead>
+                  <TableHead>Нэр</TableHead>
+                  <TableHead>Утга</TableHead>
+                  <TableHead>Төлөв</TableHead>
+                  <TableHead>Сурагч</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => {
+                  const badge = STATUS_BADGE[row.status]
+                  return (
+                    <TableRow key={row.index}>
+                      <TableCell className="text-muted-foreground">
+                        {row.index + 1}
+                      </TableCell>
+                      <TableCell>{row.rawName || '—'}</TableCell>
+                      <TableCell>{row.data || '—'}</TableCell>
+                      <TableCell>
+                        <Badge variant={badge.variant}>{badge.label}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        {row.status === 'ambiguous' && row.candidates ? (
+                          <Select
+                            value={selections[row.index] ?? ''}
+                            onValueChange={(value) =>
+                              setSelections((prev) => ({
+                                ...prev,
+                                [row.index]: value
+                              }))
+                            }
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue placeholder="Сонгох…" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {row.candidates.map((c) => (
+                                <SelectItem key={c.id} value={c.id}>
+                                  {c.name} ({c.registerNumber})
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : row.status === 'matched' ? (
+                          <span className="text-muted-foreground text-sm">
+                            {row.rawName}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">
+                            —
+                          </span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-sm">
+              Хадгалах боломжтой: {resolvedEntries.length} / {rows.length}
+            </p>
+            <Button
+              onClick={handleSave}
+              disabled={isSaving || resolvedEntries.length === 0}
+            >
+              {isSaving ? <Loader2 className="animate-spin" /> : 'Хадгалах'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/_Components/StudentInfoManager.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/_Components/StudentInfoManager.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { Loader2, Search } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+import { searchUsersByName } from '../actions'
+import type { MatchCandidate } from '../types'
+import { UserInfoEditor } from './UserInfoEditor'
+
+const GENERIC_ERROR = 'Алдаа гарлаа. Дахин оролдоно уу.'
+
+export function StudentInfoManager() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<MatchCandidate[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [selected, setSelected] = useState<MatchCandidate | null>(null)
+
+  const handleSearch = async () => {
+    if (!query.trim()) return
+    setIsSearching(true)
+    try {
+      const result = await searchUsersByName(query)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setResults(result.data)
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsSearching(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-end gap-2">
+        <div className="grid flex-1 gap-2">
+          <Label htmlFor="search">Сурагч хайх (нэрээр)</Label>
+          <Input
+            id="search"
+            placeholder="Овог эсвэл нэр"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          />
+        </div>
+        <Button onClick={handleSearch} disabled={isSearching}>
+          {isSearching ? (
+            <Loader2 className="animate-spin" />
+          ) : (
+            <Search className="size-4" />
+          )}
+        </Button>
+      </div>
+
+      {results.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {results.map((user) => (
+            <Button
+              key={user.id}
+              variant={selected?.id === user.id ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setSelected(user)}
+            >
+              {user.name} ({user.registerNumber})
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <div className="space-y-4 rounded-md border p-4">
+          <h3 className="font-semibold">{selected.name} — нэмэлт мэдээлэл</h3>
+          <UserInfoEditor key={selected.id} userId={selected.id} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/_Components/UserInfoEditor.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/_Components/UserInfoEditor.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { Check, Loader2, Pencil, Trash2, X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+
+import {
+  deleteUserInfo,
+  listUserInfo,
+  updateUserInfoById,
+  upsertUserInfo
+} from '../actions'
+import type { InfoItem } from '../types'
+
+const GENERIC_ERROR = 'Алдаа гарлаа. Дахин оролдоно уу.'
+
+export function UserInfoEditor({ userId }: { userId: string }) {
+  const [items, setItems] = useState<InfoItem[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const [newName, setNewName] = useState('')
+  const [newData, setNewData] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
+
+  // 인라인 편집 상태
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editData, setEditData] = useState('')
+  const [isSavingEdit, setIsSavingEdit] = useState(false)
+
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = await listUserInfo(userId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setItems(result.data)
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleAdd = async () => {
+    if (!newName.trim() || !newData.trim()) {
+      toast.error('Нэр болон утгыг оруулна уу')
+      return
+    }
+    setIsAdding(true)
+    try {
+      const result = await upsertUserInfo({
+        userId,
+        name: newName,
+        data: newData
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success('Хадгалагдлаа')
+      setNewName('')
+      setNewData('')
+      await load()
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  const startEdit = (item: InfoItem) => {
+    setEditingId(item.id)
+    setEditName(item.name)
+    setEditData(item.data)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditName('')
+    setEditData('')
+  }
+
+  const saveEdit = async (id: string) => {
+    if (!editName.trim() || !editData.trim()) {
+      toast.error('Нэр болон утгыг оруулна уу')
+      return
+    }
+    setIsSavingEdit(true)
+    try {
+      const result = await updateUserInfoById({
+        id,
+        name: editName,
+        data: editData
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success('Шинэчлэгдлээ')
+      cancelEdit()
+      await load()
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setIsSavingEdit(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (deletingId) return
+    setDeletingId(id)
+    try {
+      const result = await deleteUserInfo(id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      setItems((prev) => prev.filter((item) => item.id !== id))
+    } catch {
+      toast.error(GENERIC_ERROR)
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {isLoading ? (
+        <div className="flex h-24 items-center justify-center">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Нэр</TableHead>
+              <TableHead>Утга</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  className="text-center text-muted-foreground"
+                >
+                  Мэдээлэл алга байна
+                </TableCell>
+              </TableRow>
+            ) : (
+              items.map((item) =>
+                editingId === item.id ? (
+                  <TableRow key={item.id}>
+                    <TableCell>
+                      <Input
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        value={editData}
+                        onChange={(e) => setEditData(e.target.value)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={isSavingEdit}
+                          onClick={() => saveEdit(item.id)}
+                          aria-label="Хадгалах"
+                        >
+                          {isSavingEdit ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Check className="size-4 text-green-600" />
+                          )}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={isSavingEdit}
+                          onClick={cancelEdit}
+                          aria-label="Болих"
+                        >
+                          <X className="size-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.name}</TableCell>
+                    <TableCell>{item.data}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={editingId !== null || deletingId !== null}
+                          onClick={() => startEdit(item)}
+                          aria-label="Засах"
+                        >
+                          <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={
+                            editingId !== null || deletingId === item.id
+                          }
+                          onClick={() => handleDelete(item.id)}
+                          aria-label="Устгах"
+                        >
+                          {deletingId === item.id ? (
+                            <Loader2 className="size-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-4 text-destructive" />
+                          )}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              )
+            )}
+          </TableBody>
+        </Table>
+      )}
+
+      <div className="flex items-end gap-2 border-t pt-4">
+        <div className="grid flex-1 gap-2">
+          <Label htmlFor="new-name">Нэр</Label>
+          <Input
+            id="new-name"
+            placeholder="ж: ЭЕШ-ийн дугаар"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+          />
+        </div>
+        <div className="grid flex-1 gap-2">
+          <Label htmlFor="new-data">Утга</Label>
+          <Input
+            id="new-data"
+            value={newData}
+            onChange={(e) => setNewData(e.target.value)}
+          />
+        </div>
+        <Button onClick={handleAdd} disabled={isAdding}>
+          {isAdding ? <Loader2 className="animate-spin" /> : 'Нэмэх'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/_Components/UserInfoManager.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/_Components/UserInfoManager.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import { AllInfoList } from './AllInfoList'
+import { BulkInfoEditor } from './BulkInfoEditor'
+import { StudentInfoManager } from './StudentInfoManager'
+
+export function UserInfoManager() {
+  return (
+    <Tabs defaultValue="bulk" className="w-full">
+      <TabsList>
+        <TabsTrigger value="bulk">Багцаар оруулах</TabsTrigger>
+        <TabsTrigger value="single">Сурагчаар удирдах</TabsTrigger>
+        <TabsTrigger value="all">Бүх жагсаалт</TabsTrigger>
+      </TabsList>
+      <TabsContent value="bulk" className="mt-6">
+        <BulkInfoEditor />
+      </TabsContent>
+      <TabsContent value="single" className="mt-6">
+        <StudentInfoManager />
+      </TabsContent>
+      <TabsContent value="all" className="mt-6">
+        <AllInfoList />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/actions.ts
+++ b/apps/web/src/app/(sidebar)/admin/users/info/actions.ts
@@ -1,0 +1,343 @@
+'use server'
+
+import prisma from '@gt/database'
+import * as Sentry from '@sentry/nextjs'
+import { headers } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+
+import {
+  type BulkDeleteInput,
+  BulkDeleteSchema,
+  CommitBulkSchema,
+  type CommitBulkInput,
+  PreviewBulkSchema,
+  type PreviewBulkInput,
+  UpdateUserInfoByIdSchema,
+  type UpdateUserInfoByIdInput,
+  UpsertUserInfoSchema,
+  type UpsertUserInfoInput
+} from '@/schemas/userInfo'
+import { auth } from '@/utils/better-auth'
+
+import type { MatchCandidate, PreviewRow, UserInfoListRow } from './types'
+
+const MAX_EXPORT_ROWS = 10_000
+
+const INFO_PATH = '/admin/users/info'
+const MAX_SEARCH_RESULTS = 20
+const MIN_SEARCH_LENGTH = 2
+
+// 서버 액션은 클라이언트에서 독립적으로 호출 가능하므로 역할을 반드시 재검증한다.
+async function assertAdmin(): Promise<void> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (session?.user?.role !== 'ADMIN') {
+    throw new Error('Unauthorized')
+  }
+}
+
+// 이름 비교용 정규화: 공백 축약 + 소문자
+function normalizeName(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+// 붙여넣은 텍스트를 [이름, 값] 행으로 파싱한다. 탭 우선, 없으면 쉼표 fallback.
+function parseRows(raw: string): { rawName: string; data: string }[] {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const cells = (line.includes('\t') ? line.split('\t') : line.split(','))
+        .map((cell) => cell.trim())
+        .filter((cell) => cell.length > 0)
+      return { rawName: cells[0] ?? '', data: cells[1] ?? '' }
+    })
+}
+
+export async function previewBulkUserInfo(input: PreviewBulkInput) {
+  await assertAdmin()
+  const { raw } = PreviewBulkSchema.parse(input)
+
+  try {
+    const parsed = parseRows(raw)
+
+    // 정규화된 이름 → 후보 유저 목록 (성/이름 조합 포함)
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        firstName: true,
+        lastName: true,
+        registerNumber: true
+      }
+    })
+
+    const lookup = new Map<string, MatchCandidate[]>()
+    const addKey = (key: string, candidate: MatchCandidate) => {
+      const normalized = normalizeName(key)
+      if (!normalized) return
+      const list = lookup.get(normalized)
+      if (list) {
+        if (!list.some((c) => c.id === candidate.id)) list.push(candidate)
+      } else {
+        lookup.set(normalized, [candidate])
+      }
+    }
+
+    for (const user of users) {
+      const candidate: MatchCandidate = {
+        id: user.id,
+        name: user.name,
+        registerNumber: user.registerNumber
+      }
+      addKey(user.name, candidate)
+      addKey(`${user.lastName} ${user.firstName}`, candidate)
+      addKey(`${user.firstName} ${user.lastName}`, candidate)
+    }
+
+    const rows: PreviewRow[] = parsed.map((row, index) => {
+      const base = { index, rawName: row.rawName, data: row.data }
+      if (!row.rawName || !row.data) {
+        return { ...base, status: 'not_found' as const }
+      }
+      const matches = lookup.get(normalizeName(row.rawName)) ?? []
+      if (matches.length === 1) {
+        return { ...base, status: 'matched' as const, userId: matches[0].id }
+      }
+      if (matches.length > 1) {
+        return { ...base, status: 'ambiguous' as const, candidates: matches }
+      }
+      return { ...base, status: 'not_found' as const }
+    })
+
+    return { success: true as const, data: rows }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'preview-bulk' }
+    })
+    return {
+      success: false as const,
+      error: 'Урьдчилан харах үед алдаа гарлаа'
+    }
+  }
+}
+
+export async function commitBulkUserInfo(input: CommitBulkInput) {
+  await assertAdmin()
+  const { name, entries } = CommitBulkSchema.parse(input)
+
+  try {
+    await prisma.$transaction(
+      entries.map((entry) =>
+        prisma.userInfo.upsert({
+          where: { userId_name: { userId: entry.userId, name } },
+          create: { userId: entry.userId, name, data: entry.data },
+          update: { data: entry.data }
+        })
+      )
+    )
+
+    revalidatePath(INFO_PATH)
+    return { success: true as const, count: entries.length }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'commit-bulk' },
+      extra: { name, count: entries.length }
+    })
+    return { success: false as const, error: 'Хадгалах үед алдаа гарлаа' }
+  }
+}
+
+export async function searchUsersByName(query: string) {
+  await assertAdmin()
+  const trimmed = query.trim()
+  if (trimmed.length < MIN_SEARCH_LENGTH) {
+    return { success: true as const, data: [] as MatchCandidate[] }
+  }
+
+  try {
+    const users = await prisma.user.findMany({
+      where: {
+        OR: [
+          { name: { contains: trimmed, mode: 'insensitive' } },
+          { firstName: { contains: trimmed, mode: 'insensitive' } },
+          { lastName: { contains: trimmed, mode: 'insensitive' } }
+        ]
+      },
+      // 기존 UserTable과 동일하게 이름(firstName) 순으로 정렬한다.
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+      select: { id: true, name: true, registerNumber: true },
+      take: MAX_SEARCH_RESULTS
+    })
+
+    return { success: true as const, data: users }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'search-users' }
+    })
+    return { success: false as const, error: 'Хайлт амжилтгүй боллоо' }
+  }
+}
+
+export async function listUserInfo(userId: string) {
+  await assertAdmin()
+  try {
+    const items = await prisma.userInfo.findMany({
+      where: { userId },
+      orderBy: { name: 'asc' }
+    })
+    return { success: true as const, data: items }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'list' },
+      extra: { userId }
+    })
+    return { success: false as const, error: 'Жагсаалт ачаалахад алдаа гарлаа' }
+  }
+}
+
+export async function upsertUserInfo(input: UpsertUserInfoInput) {
+  await assertAdmin()
+  const { userId, name, data } = UpsertUserInfoSchema.parse(input)
+
+  try {
+    const item = await prisma.userInfo.upsert({
+      where: { userId_name: { userId, name } },
+      create: { userId, name, data },
+      update: { data }
+    })
+    revalidatePath(INFO_PATH)
+    return { success: true as const, data: item }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'upsert' },
+      extra: { userId, name }
+    })
+    return { success: false as const, error: 'Хадгалах үед алдаа гарлаа' }
+  }
+}
+
+export async function deleteUserInfo(id: string) {
+  await assertAdmin()
+  try {
+    await prisma.userInfo.delete({ where: { id } })
+    revalidatePath(INFO_PATH)
+    return { success: true as const, message: 'Устгагдлаа' }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'delete' },
+      extra: { id }
+    })
+    return { success: false as const, error: 'Устгахад алдаа гарлаа' }
+  }
+}
+
+// 선택한 항목 일괄 삭제 (PK 배열 기준)
+export async function deleteUserInfoBulk(input: BulkDeleteInput) {
+  await assertAdmin()
+  const { ids } = BulkDeleteSchema.parse(input)
+
+  try {
+    const { count } = await prisma.userInfo.deleteMany({
+      where: { id: { in: ids } }
+    })
+    revalidatePath(INFO_PATH)
+    return { success: true as const, count }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'delete-bulk' },
+      extra: { count: ids.length }
+    })
+    return { success: false as const, error: 'Устгахад алдаа гарлаа' }
+  }
+}
+
+// PK 기준 수정 (항목 이름 변경 허용). 같은 유저에 동일 이름이 이미 있으면 충돌.
+export async function updateUserInfoById(input: UpdateUserInfoByIdInput) {
+  await assertAdmin()
+  const { id, name, data } = UpdateUserInfoByIdSchema.parse(input)
+
+  try {
+    const item = await prisma.userInfo.update({
+      where: { id },
+      data: { name, data }
+    })
+    revalidatePath(INFO_PATH)
+    return { success: true as const, data: item }
+  } catch (error) {
+    // Prisma unique 제약 위반(P2002): 동일 항목 이름이 이미 존재
+    if ((error as { code?: string }).code === 'P2002') {
+      return {
+        success: false as const,
+        error: 'Тухайн нэртэй мэдээлэл аль хэдийн байна'
+      }
+    }
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'update-by-id' },
+      extra: { id, name }
+    })
+    return { success: false as const, error: 'Хадгалах үед алдаа гарлаа' }
+  }
+}
+
+// 항목 이름(scope) 기준 where 빌더. 학생 이름 검색은 클라이언트에서 처리한다.
+function buildListWhere(name?: string) {
+  return name ? { name } : {}
+}
+
+// 입력된 모든 항목 이름 (필터 드롭다운용)
+export async function listFieldNames() {
+  await assertAdmin()
+  try {
+    const rows = await prisma.userInfo.findMany({
+      distinct: ['name'],
+      select: { name: true },
+      orderBy: { name: 'asc' }
+    })
+    return { success: true as const, data: rows.map((r) => r.name) }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'list-field-names' }
+    })
+    return { success: false as const, error: 'Ачаалахад алдаа гарлаа' }
+  }
+}
+
+// 전체 목록 (학생 정보 포함, 페이지네이션)
+// 항목(scope)에 해당하는 전체 행을 한 번에 로드한다 (서버 페이지네이션 없음).
+// 페이지네이션·정렬·검색·선택은 grade/edit과 동일하게 클라이언트에서 처리한다.
+export async function loadAllUserInfo(name?: string) {
+  await assertAdmin()
+  const where = buildListWhere(name?.trim() || undefined)
+
+  try {
+    const items = await prisma.userInfo.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        data: true,
+        user: { select: { name: true, registerNumber: true } }
+      },
+      // 기본 정렬(클라이언트에서 givenNameSort로 재정렬). 상한으로 과도한 로드 방지.
+      orderBy: [{ name: 'asc' }, { updatedAt: 'desc' }],
+      take: MAX_EXPORT_ROWS
+    })
+
+    const rows: UserInfoListRow[] = items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      data: item.data,
+      studentName: item.user.name,
+      registerNumber: item.user.registerNumber
+    }))
+
+    return { success: true as const, data: rows }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { feature: 'admin-user-info', action: 'load-all' },
+      extra: { name }
+    })
+    return { success: false as const, error: 'Жагсаалт ачаалахад алдаа гарлаа' }
+  }
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/page.tsx
+++ b/apps/web/src/app/(sidebar)/admin/users/info/page.tsx
@@ -1,0 +1,48 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { AppSidebarHeader } from '@/app/(sidebar)/_Components/Header'
+import {
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator
+} from '@/components/ui/breadcrumb'
+import { auth } from '@/utils/better-auth'
+
+import { UserInfoManager } from './_Components/UserInfoManager'
+
+export default async function AdminUserInfoPage() {
+  const session = await auth.api.getSession({
+    headers: await headers()
+  })
+
+  if (session?.user?.role !== 'ADMIN') {
+    return redirect('/dash')
+  }
+
+  return (
+    <>
+      <AppSidebarHeader>
+        <BreadcrumbList>
+          <BreadcrumbItem className="hidden md:block">
+            <BreadcrumbLink href="/admin">Admin</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem className="hidden md:block">
+            <BreadcrumbLink href="/admin/users">Users</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Additional info</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </AppSidebarHeader>
+
+      <div className="md:p-6">
+        <UserInfoManager />
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/app/(sidebar)/admin/users/info/types.ts
+++ b/apps/web/src/app/(sidebar)/admin/users/info/types.ts
@@ -1,0 +1,34 @@
+// admin/users/info 기능에서 서버 액션과 클라이언트 컴포넌트가 공유하는 타입.
+// 단일 출처로 두어 반환 형태 변경 시 타입 드리프트를 막는다.
+
+export type MatchCandidate = {
+  id: string
+  name: string
+  registerNumber: string
+}
+
+export type PreviewStatus = 'matched' | 'ambiguous' | 'not_found'
+
+export type PreviewRow = {
+  index: number
+  rawName: string
+  data: string
+  status: PreviewStatus
+  userId?: string
+  candidates?: MatchCandidate[]
+}
+
+export type InfoItem = {
+  id: string
+  name: string
+  data: string
+}
+
+// 전체 목록 페이지의 한 행 (학생 정보를 평탄화하여 포함)
+export type UserInfoListRow = {
+  id: string
+  name: string
+  data: string
+  studentName: string
+  registerNumber: string
+}

--- a/apps/web/src/schemas/userInfo.ts
+++ b/apps/web/src/schemas/userInfo.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+
+const MAX_BULK_ENTRIES = 500
+
+// 추가 정보 항목 이름/값의 공통 제약
+export const UserInfoFieldSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  data: z.string().trim().min(1).max(500)
+})
+
+// 일괄 입력 미리보기 요청 (붙여넣은 원본 텍스트). 항목 이름은 저장(commit) 단계에서만 필요하다.
+export const PreviewBulkSchema = z.object({
+  raw: z.string().min(1).max(100_000)
+})
+
+// 일괄 저장 요청 (이름 매칭이 끝난 항목들)
+export const CommitBulkSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  entries: z
+    .array(
+      z.object({
+        userId: z.string().uuid(),
+        data: z.string().trim().min(1).max(500)
+      })
+    )
+    .min(1)
+    .max(MAX_BULK_ENTRIES)
+})
+
+// 개별 추가/수정 요청 (항목 이름 기준 upsert)
+export const UpsertUserInfoSchema = z.object({
+  userId: z.string().uuid(),
+  name: z.string().trim().min(1).max(100),
+  data: z.string().trim().min(1).max(500)
+})
+
+// PK 기준 수정 요청 (인라인 편집 — 항목 이름 변경 허용)
+export const UpdateUserInfoByIdSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().trim().min(1).max(100),
+  data: z.string().trim().min(1).max(500)
+})
+
+// 일괄 삭제 요청
+export const BulkDeleteSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(500)
+})
+
+// 전체 목록 조회 필터
+export const ListUserInfoQuerySchema = z.object({
+  name: z.string().trim().max(100).optional(),
+  query: z.string().trim().max(100).optional(),
+  skip: z.number().int().min(0).default(0),
+  take: z.number().int().min(1).max(100).default(20)
+})
+
+export type PreviewBulkInput = z.infer<typeof PreviewBulkSchema>
+export type CommitBulkInput = z.infer<typeof CommitBulkSchema>
+export type UpsertUserInfoInput = z.infer<typeof UpsertUserInfoSchema>
+export type UpdateUserInfoByIdInput = z.infer<typeof UpdateUserInfoByIdSchema>
+export type ListUserInfoQuery = z.infer<typeof ListUserInfoQuerySchema>
+export type BulkDeleteInput = z.infer<typeof BulkDeleteSchema>

--- a/packages/database/prisma/migrations/20260609150257_add_user_info/migration.sql
+++ b/packages/database/prisma/migrations/20260609150257_add_user_info/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "user_info" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "data" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_info_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_info_userId_idx" ON "user_info"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_info_userId_name_key" ON "user_info"("userId", "name");
+
+-- AddForeignKey
+ALTER TABLE "user_info" ADD CONSTRAINT "user_info_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -78,14 +78,32 @@ model User {
   lastName  String
   type      UserType @default(ESIS)
 
-  grades   Grade[]
-  exams    Exam[]
-  accounts Account[]
-  sessions Session[]
-  passkeys Passkey[]
+  grades    Grade[]
+  exams     Exam[]
+  accounts  Account[]
+  sessions  Session[]
+  passkeys  Passkey[]
+  userInfos UserInfo[]
 
   @@index([firstName, lastName])
   @@map("user")
+}
+
+model UserInfo {
+  id        String   @id @default(uuid())
+  userId    String
+  // 항목 이름 (예: "수능 수험번호")
+  name      String
+  // 값
+  data      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // 동일 유저에 같은 항목 재입력 시 upsert로 갱신
+  @@unique([userId, name])
+  @@index([userId])
+  @@map("user_info")
 }
 
 enum UserType {


### PR DESCRIPTION
## 개요

어드민이 ESIS 동기화와 무관한 임의의 추가 정보(예: 수능 수험번호)를 학생에게 수동으로 부여하고, 학생은 본인 프로필에서 읽기 전용으로 확인할 수 있는 기능입니다.

## 데이터 모델

- `UserInfo` 모델 추가 (`id`, `userId`, `name`, `data`, timestamps)
- `User.id` FK + `onDelete: Cascade`, `@@unique([userId, name])` (동일 항목 재입력 시 upsert 갱신)
- 마이그레이션 `20260609150257_add_user_info` — **새 테이블만 생성**(기존 데이터 손실 없음)

## 백엔드 (`admin/users/info/actions.ts`)

- 모든 서버 액션에 `assertAdmin()` 가드 + Zod 검증 + Sentry 보고
- `previewBulkUserInfo`: 엑셀 붙여넣기(탭/쉼표) 파싱 → 이름→유저 매칭(`matched`/`ambiguous`/`not_found`)
- `commitBulkUserInfo`: 트랜잭션 upsert
- `loadAllUserInfo` / `listFieldNames` / `deleteUserInfoBulk` / `updateUserInfoById` / `searchUsersByName` / `listUserInfo` / `upsertUserInfo` / `deleteUserInfo`

## 프론트엔드

새 사이드바 `/admin/users/info` (탭 3개):
- **Багцаар оруулах**: 항목명 + 엑셀 붙여넣기 → 미리보기 매칭(동명이인 선택) → 일괄 저장
- **Сурагчаар удирдах**: 학생 검색 → 추가/인라인 수정/삭제
- **Бүх жагсаалт**: 전체 목록(항목 필터 + 학생 검색 + 정렬 + 페이지네이션), **페이지 너머 전체 선택 후 일괄 삭제**, CSV 내보내기

추가 연동:
- `/admin/users` 각 유저 행에 추가 정보 관리 Sheet(📋) 버튼
- 학생 `/profile`에 추가 정보 카드(읽기 전용)

## 기존 패턴 일치

- 일괄 삭제 UX: `grade/edit`의 전체 로드 + TanStack Table + "필터 전체 선택" 패턴을 따름 (`ConfirmActionDialog` 재사용)
- 이름 정렬: `givenNameSort`(`@/utils/name`)로 기존 `UserTable`/`grade/edit`과 동일하게 이름 기준 정렬

## 테스트 계획

- [x] ADMIN → `/admin/users/info` 접근 / 비-ADMIN → `/dash` 리다이렉트
- [x] 엑셀 붙여넣기 매칭(동명이인 선택 포함) → 저장 → 재입력 시 upsert 갱신
- [x] 전체 목록에서 "전체 선택" → 페이지 너머 일괄 삭제
- [x] CSV 내보내기(엑셀에서 키릴/한글 정상 표시)
- [x] 학생 `/profile` 노출 확인

lint · tsc · build 통과 확인 완료.